### PR TITLE
Fixes Layout.js to always load correctly

### DIFF
--- a/app/components/PageList/PageList.jsx
+++ b/app/components/PageList/PageList.jsx
@@ -3,7 +3,7 @@ import { map, isEmpty } from 'lodash';
 import PageListItem from 'app/components/PageListItem';
 
 const PageList = function({ pages }) {
-  var mappedPages = 'No pages!';
+  var mappedPages = 'Loading...';
   if(!isEmpty(pages)) {
     mappedPages = map(pages.reverse(), page => {
       return <PageListItem id={page.id} src={page.image} key={page.id} />;

--- a/app/containers/Layout/Layout.js
+++ b/app/containers/Layout/Layout.js
@@ -3,19 +3,18 @@ import { isEmpty, cloneDeep, find } from 'lodash';
 import { connect } from 'react-redux';
 import { Observable } from 'rx';
 
-import { fetchLibrary, fetchBook, fetchChapter, setUpdated } from 'app/data/actions';
+import { fetchLibrary, fetchBook, fetchChapter } from 'app/data/actions';
 
 class Layout extends Component {
   constructor(props) {
     super(props);
   }
 
-  // Make sure we update our library on load
   componentWillMount() {
-    this.updateLibrary(this.props).subscribe();
+    this.updateLibrary(this.props.params).subscribe();
   }
 
-  // Also update our library whenever our location changes
+  // Update our library whenever our location changes
   componentWillReceiveProps(nextProps) {
     const currentLocation = this.props.location.pathname;
     const nextLocation = nextProps.location.pathname;
@@ -25,59 +24,61 @@ class Layout extends Component {
   }
 
   updateLibrary(params) {
+    const { dispatch, library } = this.props;
     const bookid = params.bookid || this.props.params.bookid;
     const chapterid = params.chapterid || this.props.params.chapterid;
 
-    return this.updateBooks(this.props)
+    return (!library.lastUpdated ? dispatch(fetchLibrary()) : Observable.just(this.props))
       .flatMap( () => this.updateBook(this.props, bookid))
       .flatMap( () => this.updateChapter(this.props, bookid, chapterid));
   }
 
-  updateBooks(state) {
-    const { dispatch, library } = state;
-    if(isEmpty(library.books)) {
-      return dispatch(fetchLibrary());
-    } else {
-      return Observable.just(this.props);
-    }
-  }
-
   updateBook(state, bookid) {
-    if(!state || !state.library || !state.library.books || !bookid) {
+    const { dispatch } = this.props;
+
+    if(!state.library.books || !bookid) {
       return Observable.just(state);
     }
 
-    const { dispatch } = this.props;
     const book = find(state.library.books, { id: bookid });
-    const bookNeedsUpdate = !book.lastUpdated;
-    if(!bookNeedsUpdate) {
-      return Observable.just(state);
+    const bookNeedsUpdate = !book || !book.lastUpdated;
+
+    if(bookNeedsUpdate) {
+      return dispatch(fetchBook(book));
     }
-    return dispatch(fetchBook(book));
+    return Observable.just(state);
   }
 
   updateChapter(state, bookid, chapterid) {
-    const improperState = !state || !state.library || !state.library.books;
-    const missingId = !bookid || !chapterid;
-    if(improperState || missingId) {
+    const { dispatch } = this.props;
+
+    if(!state.library.books || !bookid || !chapterid) {
       return Observable.just(state);
     }
 
-    const { dispatch } = this.props;
     const book = find(state.library.books, { id: bookid });
     const chapter = find(book.chapters, { id: chapterid });
-    const chapterNeedsUpdate = chapter && !chapter.lastUpdated;
-    if(!chapterNeedsUpdate) {
-      return Observable.just(state);
+    const chapterNeedsUpdate = Boolean(chapter && !chapter.lastUpdated);
+
+    if(chapterNeedsUpdate) {
+      return dispatch(fetchChapter(book, chapter));
     }
-    return dispatch(fetchChapter(book, chapter));
+    return Observable.just(state);
   }
 
   render() {
-    const { library, user, params } = this.props;
-    const book = library.books[params.bookid];
-    const chapter = find(book && book.chapters, { id: params.chapterid });
-    const page = (book && chapter && params.pageid) ? chapter[params.pageid] : undefined;
+    const { library, user } = this.props;
+    const { bookid, chapterid, pageid } = this.props.params;
+
+    const shouldFindBook = Boolean(library.books && bookid);
+    const book = shouldFindBook ? library.books[bookid] : undefined;
+
+    const shouldFindChapter = Boolean(book && book.chapters && chapterid);
+    const chapter = shouldFindChapter ? find(book.chapters, { id: chapterid }) : undefined;
+
+    const shouldFindPage = Boolean(book && chapter && pageid);
+    const page = shouldFindPage ? chapter[pageid] : undefined;
+
     return (
       <div className="layout">
         <h1 className="layout__title">Bentotime</h1>
@@ -87,7 +88,22 @@ class Layout extends Component {
   }
 }
 
-function select(state) {
+Layout.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  library:  PropTypes.object,
+  params:   PropTypes.object,
+  routing:  PropTypes.object,
+  user:     PropTypes.object
+};
+
+Layout.defaultProps = {
+  library: {},
+  params: {},
+  routing: {},
+  user: {}
+};
+
+function mapStateToProps(state) {
   return {
     library: cloneDeep(state.library),
     user: cloneDeep(state.user),
@@ -95,4 +111,7 @@ function select(state) {
   };
 }
 
-export default connect(select)(Layout);
+// Attaches an addition export so that we can test the component without Redux
+export const unconnected = Layout;
+
+export default connect(mapStateToProps)(Layout);

--- a/app/containers/Layout/README.md
+++ b/app/containers/Layout/README.md
@@ -1,14 +1,36 @@
-This readme is incomplete.
-
 Layout
 =========
 
-Layout is a container that is overly complex and slow, and will be changing in the near future. Keep this in mind as you read through the code.  The Layout is a container that has two main goals:
+The Layout is a container that has two main goals:
 
 1. Translate Redux State into React Props
 
-Since all of our views depend on parts of our Library and user, it makes sense that have all of that information come to head at a point, in this case the Layout. This is the only component that interacts with Redux to get Library information,
+  Since all of our views depend on parts of our Library and user, it makes sense that have all of that information come to head at a point, in this case the Layout. This is the only component that interacts with Redux to get Library information, and helps us transfer our data from our Store into props.
 
 2. Wrap our views
 
-Layout is also the main layout of the application, and has all of the persistant views. Anything that stays on-screen at all times is nested within this container.  All of our routes are displayed through this container via `React.cloneElement(this.props.children, { library, user, book, chapter })`, which also passes down the props library, user, book, and chapter.
+  Layout is also the main layout of the application, and has all of the persistant views. Anything that stays on-screen at all times is nested within this container.  All of our routes are displayed through this container via `React.cloneElement`, which also passes down the props library, user, book, chapter, and page.
+
+#### How to use
+Layout is meant to be used with Redux and as a wrapper of other components (more specifically with React-Router).
+
+```js
+import Layout from 'app/components/Layout';
+
+<Provider store={myStore}>
+  <Layout>
+    <ChildComponent />
+  </Layout>
+</Provider>
+
+<Layout  />
+```
+
+The non-redux connected component is also exported as an `unconnected` property in the exported Class.
+
+#### Props
+* `dispatch`: Given to us by React-Redux, this allows us to dispatch actions to our Store.
+* `library`: All of our manga data as a Library model
+* `params`: Given to us by React-Router, this gives us our url parameters
+* `routing`: Given to us by React-Router-Redux, this gives us information about our route
+* `user`: Determined by our User model, this gives us various information and settings related to our user.

--- a/app/containers/Layout/testfile.js
+++ b/app/containers/Layout/testfile.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { find } from 'lodash';
+import { Observable } from 'rx';
+import TestUtils from 'react/lib/ReactTestUtils';
+
+describe('Containers', function() {
+  describe('Layout', function() {
+    beforeEach(function beforeEach() {
+      this.mockActions = {
+        fetchLibrary: sinon.stub().returns('todo: use library fixture here'),
+        fetchBook: sinon.stub().returns('todo: use book fixture here'),
+        fetchChapter: sinon.stub().returns('todo: use chapter fixture here')
+      };
+
+      let layoutInjector = require('inject!app/containers/Layout');
+      this.Layout = layoutInjector({ 'app/data/actions': this.mockActions }).unconnected;
+
+      this.props = {
+        library: { lastUpdated: '12345' },
+        dispatch: sinon.stub().returns(Observable.just({})),
+        params: {},
+        routing: {},
+        user: {}
+      };
+
+      this.component = TestUtils.renderIntoDocument(
+        <this.Layout {...this.props}>
+          <div className="layout__child" />
+        </this.Layout>
+      );
+    });
+
+    it('Should render a div with a `layout` class', function shouldRenderLayout() {
+      let layoutInstance = TestUtils.findRenderedDOMComponentWithClass(this.component, 'layout');
+      expect(layoutInstance.children).to.exist;
+    });
+
+    it('Should render the title BentoTime', function shouldRenderTitle() {
+      let title = TestUtils.findRenderedDOMComponentWithClass(this.component, 'layout__title');
+      expect(title.tagName).to.equal('H1');
+      expect(title.textContent).to.equal('Bentotime');
+    });
+
+    it('Should render children', function shouldRenderChildren() {
+      let child = TestUtils.findRenderedDOMComponentWithClass(this.component, 'layout__child');
+      expect(child.tagName).to.equal('DIV');
+    });
+
+    it('Should not fetch anything if nothing needs to be updated', function shouldNotUpdate() {
+      expect(this.mockActions.fetchLibrary.callCount).to.equal(0);
+      expect(this.mockActions.fetchBook.callCount).to.equal(0);
+      expect(this.mockActions.fetchChapter.callCount).to.equal(0);
+    });
+
+    it('Should fetch Library if it needs to be updated', function shouldFetchLibrary() {
+      this.props.library.lastUpdated = undefined;
+
+      this.component = TestUtils.renderIntoDocument(
+        <this.Layout {...this.props}>
+          <div className="layout__child" />
+        </this.Layout>
+      );
+
+      expect(this.mockActions.fetchLibrary.callCount).to.equal(1);
+      expect(this.mockActions.fetchBook.callCount).to.equal(0);
+      expect(this.mockActions.fetchChapter.callCount).to.equal(0);
+    });
+
+    it('Should fetch any books that need to be updated', function shouldFetchBook() {
+      this.props.params.bookid = 'some-book';
+      this.props.library.books = {
+        'some-book': {
+          id: 'some-book'
+        }
+      };
+
+      this.component = TestUtils.renderIntoDocument(
+        <this.Layout {...this.props}>
+          <div className="layout__child" />
+        </this.Layout>
+      );
+
+      const book = this.props.library.books['some-book'];
+      expect(this.mockActions.fetchBook.calledWithExactly(book)).to.be.true;
+      expect(this.mockActions.fetchLibrary.callCount).to.equal(0);
+      expect(this.mockActions.fetchChapter.callCount).to.equal(0);
+    });
+
+    it('Should fetch any chapters that need to be updated', function shouldFetchChapter() {
+      this.props.params.bookid = 'some-book';
+      this.props.params.chapterid = 'some-chapter';
+      this.props.library.books = {
+        'some-book': {
+          id: 'some-book',
+          lastUpdated: '12345',
+          chapters: [{ id: 'some-chapter' }]
+        }
+      };
+
+      this.component = TestUtils.renderIntoDocument(
+        <this.Layout {...this.props}>
+          <div className="layout__child" />
+        </this.Layout>
+      );
+
+      const book = this.props.library.books['some-book'];
+      const chapter = find(book.chapters, {id: 'some-chapter'});
+      expect(this.mockActions.fetchChapter.calledWithExactly(book, chapter)).to.be.true;
+      expect(this.mockActions.fetchLibrary.callCount).to.equal(0);
+      expect(this.mockActions.fetchBook.callCount).to.equal(0);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-react": "^3.11.2",
     "extract-text-webpack-plugin": "^1.0.1",
     "html-loader": "^0.4.0",
+    "inject-loader": "^2.0.1",
     "json-loader": "^0.5.4",
     "karma": "^0.13.10",
     "karma-chai": "^0.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div>
-  	 <div id="mountPoint" />
+  	  <div id="mountPoint" />
     </div>
     <script async src="build/main.js"></script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,9 @@
     <link rel="stylesheet" type="text/css" href="build/styles.css" />
   </head>
   <body>
-  	<div id="mountPoint" />
+    <div>
+  	 <div id="mountPoint" />
+    </div>
     <script async src="build/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Background

There was significant problems with the clarity and the cleanliness of Layout.js, leading to issue https://github.com/Blanket-Warriors/BentoTime/issues/16.  This PR cleans up Layout.js, solves that bug, and adds some testing and documentation.

# Changes

 - [x] Cleans up Layout.js so the logic is easier to follow
 - [x] Let all pages render correctly with all of their data
 - [x] Write tests for Layout.js (More can still be done here, but it's slightly difficult without diving into private properties).
 - [x] Adds `inject-loader` for webpack, so we can inject mock import dependencies and unit test modules on a smaller scale.
 - [x] Adds documentation for Layout.js

# References

Layout.js Cleanup - https://github.com/Blanket-Warriors/BentoTime/issues/7
Doesn't Render Correctly when cold-calling a Chapter - https://github.com/Blanket-Warriors/BentoTime/issues/16

# Reviewers

@mistermjtek @ddrabik @aj-adams 