### PR TITLE
Adds filter to BookList

### DIFF
--- a/app/components/BookList/BookList.jsx
+++ b/app/components/BookList/BookList.jsx
@@ -1,16 +1,44 @@
 import React from 'react';
-import { map } from 'lodash';
+import _ from 'lodash';
 import BookListItem from 'app/components/BookListItem';
 
-const BookList = function({ books }) {
-  const mappedBooks = map(books, book => {
-    return <BookListItem key={book.id} book={book} />;
-  });
+const BookList = function({ books, filter }) {
+
+  const mappedBooks = _(books)
+    .filter(book => {
+      if(typeof filter === 'boolean') {
+        return filter;
+      }
+
+      if(typeof filter === 'string' && filter.length > 0) {
+        // Assume that if a user only types in `n`, they want something that starts with `n`.
+        // Cut-off point for filtering from the beginning is 3 characters.
+        if(filter.length <= 3) {
+          const matchFromBeginning = new RegExp('^' + filter, 'gi');
+          return Boolean(book.title.match(matchFromBeginning));
+        } else {
+          const matchAnywhere = new RegExp(filter, 'gi')
+          return Boolean(book.title.match(matchAnywhere));
+        }
+      }
+
+      return false;
+    })
+    .sortBy('alias')
+    .map(book => {
+      return <BookListItem key={book.id} book={book} />;
+    })
+    .value();
+
   return <ul className="book-list">{mappedBooks}</ul>;
 };
 
 BookList.propTypes = {
-  books: React.PropTypes.object.isRequired,
+  books: React.PropTypes.object.isRequired
+};
+
+BookList.defaultProps = {
+  filter: null
 };
 
 export default BookList;

--- a/app/components/BookList/README.md
+++ b/app/components/BookList/README.md
@@ -5,12 +5,32 @@ BookList takes in an object or array of books, and returns a list component that
 
 #### How to use:
 
+##### With Filter
+BookList is very stingy on displaying books, and will only display books matched by the filter. This helps us speed up our application by reducing the amount of components rendered. We filter our `BookList` by passing in a `filter` prop. The `filter` prop is a string that we use to match against the manga titles, ignoring case:
+
 ```js
 import BookList from 'app/components/BookList';
+const myBooks = [/*An array of books*/];
+const filterString = "naruto";
 
-<BookList books={books} />
+<BookList books={myBooks} filter={filterString} />
+```
+
+##### Without Filter
+The basic usage of the BookList component without a filter is to pass filter a boolean value:
+
+```js
+import BookList from 'app/components/BookList';
+const myBooks = [/*An array of books*/];
+
+// displays no books
+<BookList books={myBooks} filter={false} />
+
+// displays all books
+<BookList books={myBooks} filter={true} />
 ```
 
 #### Props
 
 * `books`: An object or array of [Books](../../data/models/Book)
+* `filter`: What we use to filter book titles. As of now, this can be a string or boolean. A boolean can be used to display the entire or none of the list, where a string is used to search through the title of each book.

--- a/app/components/BookList/testfile.jsx
+++ b/app/components/BookList/testfile.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import TestUtils from 'react/lib/ReactTestUtils';
+import BookList from 'app/components/BookList';
+
+describe('Components', function() {
+  describe('BookList', function() {
+    var shallowRenderer;
+    var node;
+    var books;
+
+    beforeEach(function() {
+      node = document.createElement('div');
+      shallowRenderer = TestUtils.createRenderer();
+      books = {
+        "flappy-monkey": {
+          id: "flappy-monkey",
+          title: "Flappy Monkey Banana Attack"
+        },
+        "flappy-monkey-2": {
+          id: "flappy-monkey-2",
+          title: "Return of the Flappy Monkey"
+        }
+      };
+    });
+
+    it('Should render an `ul` tag', function renderBookList() {
+      shallowRenderer.render( <BookList books={books} /> );
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.type).to.equal('ul');
+    });
+
+    it('Should not any books if filter prop is empty', function emptyProp() {
+      shallowRenderer.render( <BookList books={books} /> );
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.equal(0);
+    });
+
+    it('Should display no books if filter prop is false', function falseProp() {
+      shallowRenderer.render( <BookList books={books} filter={false} /> );
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.equal(0);
+    });
+
+    it('Should display all books if filter prop is true', function trueProp() {
+      shallowRenderer.render( <BookList books={books} filter={true} /> );
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.equal(2);
+    });
+
+    it('Should filter titles by string', function filterBookListByString() {
+      shallowRenderer.render( <BookList books={books} filter="Return of the" />) ;
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.equal(1);
+    });
+
+    it('Should filter at the beginning of the title if filter is less than 3 characters', function filterBookListByString() {
+      shallowRenderer.render( <BookList books={books} filter="Fla" />) ;
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.equal(1);
+    });
+
+    it('Should not display all books if filter prop is the string true', function trueStringProp() {
+      shallowRenderer.render( <BookList books={books} filter={"true"} /> );
+      const BookListInstance = shallowRenderer.getRenderOutput();
+      expect(BookListInstance.props.children.length).to.not.equal(2);
+    });
+  });
+});

--- a/app/containers/LibraryView/LibraryView.js
+++ b/app/containers/LibraryView/LibraryView.js
@@ -1,17 +1,43 @@
-import React from 'react';
-
+import React, { Component } from 'react';
 import BookList from 'app/components/BookList';
+import { bind, debounce } from 'lodash';
 
-const LibraryView = function LibraryView({ library }) {
-  if(library.lastUpdated) {
-    return (
-      <div className="library-view">
-        <BookList books={library.books} />
-      </div>
-    );
+class LibraryView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { searchFilter: '' };
+
+    this.onSearch = bind(this.onSearch, this);
+    this.updateSearchState = debounce( searchFilter => {
+      this.setState({searchFilter: searchFilter});
+    }, 350);
   }
-  return <div>loading...</div>;
-};
+
+  onSearch(event) {
+    const searchFilter = event.target.value;
+    this.updateSearchState(searchFilter);
+  }
+
+  render() {
+    const library = this.props.library;
+    const searchFilter = this.state.searchFilter;
+
+    if(library.lastUpdated) {
+      return (
+        <div className="library-view">
+          <input
+            className="library-view__search"
+            type="search"
+            onChange={this.onSearch}
+            placeholder="Search..."
+          />
+          <BookList books={library.books} filter={this.state.searchFilter} />
+        </div>
+      );
+    }
+    return <div>loading...</div>;
+  }
+}
 
 LibraryView.defaultProps = {
   library: {}

--- a/app/containers/LibraryView/testfile.js
+++ b/app/containers/LibraryView/testfile.js
@@ -8,7 +8,16 @@ describe('Containers', function() {
     beforeEach(function() {
       this.library = {
         lastUpdated: 12345,
-        books: {}
+        books: {
+          "flappy-monkey": {
+            id: "flappy-monkey",
+            title: "Flappy Monkey Banana Attack"
+          },
+          "flappy-monkey-2": {
+            id: "flappy-monkey-2",
+            title: "Return of the Flappy Monkey"
+          }
+        }
       };
 
       const shallowRenderer = TestUtils.createRenderer();
@@ -22,8 +31,8 @@ describe('Containers', function() {
     });
 
     it('Should render a BookList component, and pass it all of our books', function() {
-      const bookList = this.component.props.children;
-      expect(bookList.books).to.equal(this.books);
+      const bookList = this.component.props.children[1].props.books;
+      expect(bookList).to.equal(this.library.books);
     });
 
     it('Should render a Loading component if it has never been updated', function() {


### PR DESCRIPTION
# Background

Resubmission of PR https://github.com/Blanket-Warriors/BentoTime/pull/26. Fixes issue https://github.com/Blanket-Warriors/BentoTime/issues/13, where the load time was terrible due to the massive amount of rendering for all the manga titles. This quick fix utilizes a filter so that we initially don't render the entire library. This decreases the initial load time but, more importantly, erases the crazy load time that was occurring even AFTER the book list had been downloaded. The way the filter works is that for the first 3 characters someone types, it looks at the beginning of titles.  After this, it looks anywhere in the title. We can also manually control the filter with booleans.

# Changes 

 - [x] Adds filter prop and functionality to BookList
 - [x] Adjusts tests/documentation of BookList to match
 - [x] Adjusts LibraryView to use the filter functionality with a debounce
   for performance

Initial Load:
<img width="1114" alt="untitled" src="https://cloud.githubusercontent.com/assets/8182843/13993067/f4fe92de-f0db-11e5-95e4-1d4d8c79c2b0.png">

If someone types in less than 3 characters, look at the beginning of the Title...
<img width="1127" alt="untitled 2" src="https://cloud.githubusercontent.com/assets/8182843/13993068/f5edb364-f0db-11e5-9fa9-f7f1f249f0c7.png">

Else look throughout the title...
<img width="1142" alt="untitled 3" src="https://cloud.githubusercontent.com/assets/8182843/13993055/e4b01d9e-f0db-11e5-80c8-b8ff3c2a2f32.png">

# Reference

Issue https://github.com/Blanket-Warriors/BentoTime/issues/13

# Reviewers

@aj-adams  @ddrabik @mistermjtek 