### PR TITLE
Adds Github Integration files to repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to BentoTime
+
+Use our [contribution repo](https://github.com/Blanket-Warriors/Style-Guide/tree/master/Contribution) to get an idea of the format we expect for PR's, commits, and issues. Using this, and making sure to run our Linter and Unit tests will make a big help towards getting your PR's merged in a timely manner. Cheers!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+# Description
+
+A description that describes the problem
+
+# Steps to Reproduce
+
+1. The steps required to get to the state...
+2. where the error occurs
+
+# Expected
+
+If the issue is a bug, what are we expected to see?
+
+# Actual
+
+How does that differ from what we are seeing?
+
+# Needed
+
+- [ ] Do the thing
+- [ ] Test the thing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Background
+
+Description of why this PR was needed. Hopefully screenshots of the problem are already present in the Issue page of the PR, so this won't be needed here.
+
+# Changes
+
+- [x] Something that changed
+- [x] Another thing that changed
+- [ ] Something didn't change
+
+[Include screenshots of the changes here if relevant]
+
+# References
+
+ - Issue https://github.com/Blanket-Warriors/BentoTime/issues/27
+
+# Reviewers
+
+@ivebencrazy

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,12 @@
+# .github
+
+This is a directory that holds Github related files. This includes templates, and a link to our contribution guide.
+
+##### ISSUE_TEMPLATE.md
+
+Given to us in [this Github update](https://github.com/blog/2111-issue-and-pull-request-templates), this lets us create a template for Github Issues. We use Github issues because it keeps all of our concerns organized in the same place. This template just saves us some typing/copypasta.
+
+
+##### PULL_REQUEST_TEMPLATE.md
+
+Given to us in the same update as [Issue templates](https://github.com/blog/2111-issue-and-pull-request-templates), we can also make a template for PR's! It does the same thing as `ISSUE_TEMPLATE.md`.


### PR DESCRIPTION
# Background

Github released the ability to auto-apply templates for Pull Requests and Github Issues.  Figured this would save a lot of typing for our poor souls. Also took the chance to add a .CONTRIBUTING Github file as well, since I was already adding Github files.

# Changes

 - [x] Creates `.github` directory
 - [x] Adds `ISSUE_TEMPLATE` to the new directory
 - [x] Adds `PULL_REQUEST_TEMPLATE` to the new directory
 - [x] Adds `CONTRIBUTING` to the new directory
 - [x] Adds a readme  to the new directory

# References

 - [Github's blog post on the update](https://github.com/blog/2111-issue-and-pull-request-templates)
 - Issue https://github.com/Blanket-Warriors/BentoTime/issues/27

# Reviewers

@aj-adams @mistermjtek @ddrabik 