### PR TITLE
Adds dependency info to README and adds bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,37 +4,149 @@
 # BentoTime
 A native pc/mac/linux app for reading and saving manga.
 
-## Usage
+## Starting Development
   - install dependencies - `npm install`
-  - make sure all the tests are running - `npm test`
-  - run Webpack dev server - `npm start`
-  
-### Electron
-Run these two commands simultaneously in different console tabs.
-`npm start`
-`npm run electron`
+  - Make sure all the tests are running - `npm test`
+  - Run Webpack dev server and electron - `npm run dev-server`
+  - Either open the app in a browser by pointing at `localhost:8080`, or open an electron app with `npm run electron`.
 
 ## Contributing
 Use our [contribution repo](https://github.com/Blanket-Warriors/Style-Guide/tree/master/Contribution) to get an idea of the format we expect for PR's, commits, and issues.
 
-## Technologies
-### Electron
-[Electron](http://electron.atom.io/) lets us build native desktop applications using web technologies!
-
-### React
-[React](https://facebook.github.io/react/) helps us render the views of our application.
-
-### Redux
-[Redux](http://rackt.org/redux/) is a library that helps us manage the dataflow of our application.
-
-### Lodash
-[Lodash](https://lodash.com/docs) is a very solid and fast library of utility functions. Their documentation is fantastic, and we supply links in our readmes whenever possible.
-
-### RxJs
-[RxJs](http://reactivex.io/) is a library that allows us to deal with asynchronous problems using the concept of observables. This is awesome because it allows us to deal with one interface when using asynchronous tasks that might normally be handled in different ways, such as api requests, streams, and listener events. Admittedly, it is not used to its fullest potential in this project because we mainly deal with simple api requests. However we thought it was a good learning opportunity and think that observables are just kinda cool. If you would like to get more into programming in this style, we'd recommend taking a look at [Jafar Husain's tutorial](http://reactivex.io/learnrx/), which is just awesome.
-
-### Webpack
-[Webpack](https://webpack.github.io/) is a tool to help us compile and package our Javascript.  This allows us to use [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html), [SASS](http://sass-lang.com/) and cool new Javascript features via [Babel](https://babeljs.io/). The [React Webpack Cookbook](https://christianalfoni.github.io/react-webpack-cookbook/index.html) is a pretty good place to start getting used to using Webpack with React.
-
 ## License
 MIT © [Blanket Warriors](http://blanketwarriors.com)
+
+## Dependencies
+These are the main dependencies of BentoTime, and if you intend to use this repository to learn, these are the technologies you should be focusing on. Have fun and good luck!
+
+- #### Lodash
+[Lodash](https://lodash.com/docs) is a very solid and fast library of utility functions. Their documentation is fantastic, and we supply links in our readmes whenever possible.
+
+- #### React
+[React](https://facebook.github.io/react/) helps us structure the views of our application.
+
+- #### React-DOM
+Starting at React v.0.14, Facebook split out React's DOM functionality into [React-DOM](https://facebook.github.io/react/). This probably had to do with the fact that people were using React in all sorts of different contexts, like [React Native](https://facebook.github.io/react-native/), [React Canvas](https://github.com/Flipboard/react-canvas), and other custom translations. However, we're just making a simple web app, so all this means is that we use the React-DOM module where we attach our React components to a node on the HTML DOM.
+
+- #### React-Redux
+[React-Redux](https://github.com/reactjs/react-redux) connects React and Redux together with a few small helpers.
+
+- #### React-Router
+[React-Router](https://github.com/reactjs/react-router) is the cleanest router available for React. It helps us keep track of all our container views.
+
+- #### React-Router-Redux
+[React-Router-Redux](https://github.com/reactjs/react-router-redux) helps us keep the state of React-Router in sync with the state of Redux.
+
+- #### Redux
+[Redux](https://github.com/reactjs/redux) is a bit of a pattern we use for storing our state. Redux gives us our store and dispatcher. It's a library that helps us manage the dataflow of our application.
+
+- #### Redux-Logger and Redux-Devtools
+[Redux-Logger](https://github.com/fcomb/redux-logger) and [Redux-Devtools](https://github.com/gaearon/redux-devtools) are just tools to help us debug our application.
+
+- #### Redux-Thunk
+[Redux-Thunk](https://github.com/gaearon/redux-thunk) helps us deal with asynchronous tasks using action creators that return functions instead of actions.
+
+- #### Rx
+[RxJs](http://reactivex.io/) is a library that allows us to deal with asynchronous problems using the concept of observables. This is awesome because it allows us to deal with one interface when using asynchronous tasks that might normally be handled in different ways, such as api requests, streams, and listener events. Admittedly, it is not used to its fullest potential in this project because we mainly deal with simple api requests. However we thought it was a good learning opportunity and think that observables are just kinda cool. If you would like to get more into programming in this style, we'd recommend taking a look at [Jafar Husain's tutorial](http://reactivex.io/learnrx/), which is just awesome.
+
+- #### Superagent
+[Superagent](https://github.com/visionmedia/superagent) is an abstraction over javascript AJAX tools, and just makes dealing with requests really easy. We use it whenever we ping an api for Manga data.
+
+## DevDependencies
+These are dependencies that are not used much in the actual application, but facilitate it in building and using the application. This notably includes Electron, our compliation dependencies, and testing dependencies.
+
+- #### Babel-Core
+We use [Babel](https://babeljs.io/) to compile our Javascript with new features into plain old ES5. This helps us maintain compatibility with the Chrome runtime, while simultaneously letting us use all the new Javascript features.
+
+- #### Babel-ESLint
+Lets our ESLint understand our Babel ways. Basically, ESLint is just a platform, and [Babel-ESLint](https://github.com/babel/babel-eslint) tells ESLint what to look for.
+
+- #### Babel-Loader
+Lets us use Babel with Webpack. Basically, Webpack runs Babel whenever it sees a `.js` or `.jsx` module. [Babel-Loader](https://github.com/babel/babel-loader) just tells Webpack how to use Babel. Yay loaders.
+
+- #### Babel-preset-es2015
+[Babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/) makes sure we have all the standart es2015 features like arrow fun-ctions, lets, consts, etc.
+
+- #### Babel-preset-react
+[Babel-preset-react](http://babeljs.io/docs/plugins/preset-react/) is used by Babel to compile our JSX features.
+
+- #### Babel-preset-stage-0
+[Babel-preset-stage-0](https://babeljs.io/docs/plugins/preset-stage-0/) lets us use the very cutting edge Javascript. So a bit more liable to change, but lets us use the cool shit.
+
+- #### Chai
+[Chai](https://duckduckgo.com/?q=chai+test) is an assertion library (gives us all our `expects`, `asserts`, etc). We use it for testing, and it works. Not much to say here.
+
+- #### CSS-Loader
+[CSS-Loader](https://github.com/MoOx/eslint-loader) is how we integrate our CSS compilation into our Webpack process.
+
+- #### Electron-Packager and Electron-BuildPbooer
+[Electron-Packager](https://github.com/electron-userland/electron-packager) and [Electron-Builder](https://github.com/electron-userland/electron-builder)are meant to be used together to create the applications for actual distribution. Our packager helps us make our `.exe` or `.app` file, while Builder helps us create the installation package. We have not yet implemented our build process with these, but it's coming soon!
+
+- #### Electron-Debug
+[Electron-Debug](https://github.com/sindresorhus/electron-debug) adds the Chrome debugging tools into Electron! Not much to say about that besides the fact that it's just plain useful.
+
+- #### Electron-Prebuilt
+[Electron](http://electron.atom.io/) lets us build native desktop applications using web technologies! [Electron-Prebuilt](https://github.com/electron-userland/electron-prebuilt), specifically, is for development, and lets us run our Electron application without compiling anything.
+
+- #### ESLint
+[ESLint](http://eslint.org/) is a great tool that catches our mistakes before we run our stuff. We integrate it with our Webpack process in order to catch mistakes before we compile all of our code. It also helps us keep our coding-styles in sync, so it's easier to read through our repository. You'll also notice our .eslintignore and .eslintrc.js files, which are simply configuration details for ESLint.
+
+- #### ESLint-Loader
+[ESLint-Loader](https://github.com/MoOx/eslint-loader) is a Webpack loader for ESLint. It's how we integrate ESLint with our Webpack processes.
+
+- #### ESLint-Plugin-React
+[ESLint-Plugin-React](https://github.com/yannickcr/eslint-plugin-react) gives us special React-inspired rules, and lets us check our JSX with ESLint (otherwise it'll totes freak out as soon as it sees the first `<myComponent />`).
+
+- #### Extract-Text-Webpack-Plugin
+[Extract-Text-Webpack-Plugin](https://github.com/webpack/extract-text-webpack-plugin) Separates our compiled stylesheet and Javascript files. It will give us a slight performance boost as the amount of stylesheets grows, as we don't need to wait for the Javascript to run in order to use our styles. We might actually just move this into the production build rather than have it in both the production and development builds, since it does add a little time to our compilation process and blocks [hot module replacement](https://webpack.github.io/docs/hot-module-replacement.html) from happening.
+
+- #### Inject-Loader
+[Inject-Loader](https://github.com/plasticine/inject-loader) is for testing that lets us inject modules into our modules to write unit tests where we would want to mock things inside our module. Basically, if we do this, then we can say "Oh. This module failed", instead of "Oh. Either this module or any one of its dependencies failed".
+
+- #### Karma
+[Karma](https://karma-runner.github.io/0.13/index.html) is the actual tool that runs our tests. It opens up a web browser, uses that browser to run all of our test code, and displays the results. Since this is the actual thing running our tests, ALL of the test code comes through here, making it a central part of our testing scheme.
+
+- #### Karma-Chrome-Launcher
+[This is the thing that launches said web browser from Karma](https://github.com/karma-runner/karma-chrome-launcher). We are using Chrome, since Electron uses the Chrome runtime for all its shenanigans. We don't have to worry about compatibility with other browsers. And yes, you must have Chrome installed to use this.
+
+- #### Karma-cli
+[Karma-CLI](https://github.com/karma-runner/karma-cli) lets us run the sweet, sweet Karma commands.  Should probably install this with `-g`, but what the hell. We click Karma from our package.json, so yeah that's what's happening there.
+
+- #### Karma-Mocha
+Remember how we said everything testing runs through Karma? Yup, [Karma-Mocha](https://github.com/karma-runner/karma-mocha) helps Mocha run through Karma.  Surprise.
+
+- #### Karma-Mocha-Reporter
+[Karma-Mocha-Reporter](https://github.com/litixsoft/karma-mocha-reporter) actually doesn't have all that much to do with Mocha. It literally is just imitating what the Mocha CLI looks like, so we can make Karma results populate in a not-ugly way.
+
+- #### Karma-Sinon
+Ooooo wow [another](https://github.com/yanoosh/karma-sinon) Karma plugin to make something work. This time it's Sinon.
+
+- #### Karma-Sourcemap-Loader
+Since our compiled code's line numbers don't match our uncompiled line numbers, we use source maps. [Karma-Sourcemap-Loader](https://github.com/demerzel3/karma-sourcemap-loader) maps one line to the other, so we can get pretty line numbers. You'll notice when we compile, we are also given map files in our `public/build` folder. Yup. That's what those are for.
+
+- #### Karma-Webpack
+[Karma. Using. Webpack.](https://github.com/webpack/karma-webpack)
+
+- #### Mocha
+For testing! [Mocha](https://mochajs.org/) helps us describe the structure of our tests. It gives us our describe blocks, as well as a lot of utility. It's one of the important testing technologies we use along with Karma, Sinon, Chai, and Inject-Loader.
+
+- #### Node-Sass
+[Node-Sass](https://github.com/sass/node-sass) lets us use Sass by compiling our `.scss` files. Sass is dabes. Use Sass.
+
+- #### Sass-Loader
+[Sass-Loader](https://github.com/jtangelder/sass-loader) integrates our Node-Sass compilation to run inside Webpack. Aww yeee.
+
+- #### Sinon
+[Sinon](http://sinonjs.org/) is basically a massive library of test-related utilities. Huuuuugely useful library for testing anything and everything. We talk about it more in our `/test` directory READMEs.
+
+- #### Source-Map-Support
+[Moar source map](https://www.npmjs.com/package/source-map-support)!
+
+- #### Webpack
+[Webpack](https://webpack.github.io/) is a tool to help us compile and package our Javascript, and represents the centerpiece of our build process. It allows us to use [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html), [SASS](http://sass-lang.com/) and cool new Javascript features via [Babel](https://babeljs.io/) by taking code we write in those technologies, parsing them, and spitting our plain old CSS and EcmaScript5. The [React Webpack Cookbook](https://christianalfoni.github.io/react-webpack-cookbook/index.html) is a pretty good place to start getting used to using Webpack with React.
+
+- #### Webpack-dev-server
+[Webpack-Dev-Server](https://github.com/webpack/webpack-dev-server) is some cool webpack middleware that runs a development server, automatically updates when our code changes. Means we can check our work faster.
+
+- #### Webpack-Hot-Middleware
+Not implemented, but [Webpack-Hot-Middleware](https://github.com/glenjamin/webpack-hot-middleware) lets Webpack-Dev-Server reload individual modules at a time. The glory in this is that it means when we make a code change, our test app can stay in the same state. AKA it doesn't restart every. friggin. time. For more info on that, read [webpack's introduction to Hot Module Replacement](https://webpack.github.io/docs/hot-module-replacement-with-webpack.html)

--- a/app/components/BookList/BookList.jsx
+++ b/app/components/BookList/BookList.jsx
@@ -10,7 +10,7 @@ const BookList = function({ books }) {
 };
 
 BookList.propTypes = {
-  books: React.PropTypes.object.isRequired,
+  books: React.PropTypes.object.isRequired
 };
 
 export default BookList;

--- a/app/components/BookListItem/BookListItem.jsx
+++ b/app/components/BookListItem/BookListItem.jsx
@@ -6,7 +6,7 @@ const BookListItem = function({ key, book }) {
     <li className="book-list-item" key={key}>
       <Link
         className="book-list-item__name"
-        to={"book/" + book.id}
+        to={`book/${book.id}`}
       >
         {book.title}
       </Link>

--- a/app/components/BookListItem/testfile.jsx
+++ b/app/components/BookListItem/testfile.jsx
@@ -4,25 +4,19 @@ import BookListItem from 'app/components/BookListItem';
 
 describe('Components', function() {
   describe('BookListItem', function() {
-    var shallowRenderer;
-    var node;
-    var book;
-
     beforeEach(function() {
-      node = document.createElement('div');
-      shallowRenderer = TestUtils.createRenderer();
+      this.shallowRenderer = TestUtils.createRenderer();
+      this.book = null;
     });
 
     it('Should render an `li` tag with appropriate props', function renderBookListItem() {
-      book = {
-        id: "flappy-monkey",
-        title: "Flappy Monkey Banana Attack"
-      }
+      this.book = {
+        id: 'flappy-monkey',
+        title: 'Flappy Monkey Banana Attack'
+      };
 
-      shallowRenderer.render(
-        <BookListItem key="key1" book={book} />
-       );
-      const BookListItemInstance = shallowRenderer.getRenderOutput();
+      this.shallowRenderer.render(<BookListItem key="key1" book={this.book} />);
+      const BookListItemInstance = this.shallowRenderer.getRenderOutput();
       expect(BookListItemInstance.type).to.equal('li');
     });
   });

--- a/app/components/ChapterList/ChapterList.jsx
+++ b/app/components/ChapterList/ChapterList.jsx
@@ -16,7 +16,7 @@ const ChapterList = function({ book }) {
 };
 
 ChapterList.propTypes = {
-  book: React.PropTypes.object.isRequired,
+  book: React.PropTypes.object.isRequired
 };
 
 export default ChapterList;

--- a/app/components/Img/Img.jsx
+++ b/app/components/Img/Img.jsx
@@ -17,7 +17,7 @@ class Img extends React.Component {
       <img src={ this.state.src } onError={ this._handleError } {...this.props} />
     );
   }
-};
+}
 
 Img.propTypes = {
   src: React.PropTypes.string.isRequired,

--- a/app/components/Link/Link.jsx
+++ b/app/components/Link/Link.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const Link = function(props) {
-  return <Link className={"nav-link " + props.className} {...props} />
+  return <Link className={'nav-link ' + props.className} {...props} />;
 };
 
 Link.propTypes = {

--- a/app/components/Link/testfile.jsx
+++ b/app/components/Link/testfile.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Router, Route } from 'react-router'
+import { Router, Route } from 'react-router';
 import { render, findDOMNode } from 'react-dom';
 import { createRenderer } from 'react/lib/ReactTestUtils';
-import createHistory from 'history/lib/createMemoryHistory'
+import createHistory from 'history/lib/createMemoryHistory';
 import Link from './Link';
 
 describe('Components', function() {
@@ -19,7 +19,7 @@ describe('Components', function() {
       class LinkWrapper extends React.Component {
         render() {
           return (
-            <Link to='/blog' path='/home' query={{the: 'query'}} hash="#hash">
+            <Link to="/blog" path="/home" query={{the: 'query'}} hash="#hash">
               Home
             </Link>
           );
@@ -28,12 +28,12 @@ describe('Components', function() {
 
       render((
         <Router history={createHistory('/home')}>
-          <Route path='/home' component={LinkWrapper} />
+          <Route path="/home" component={LinkWrapper} />
         </Router>
         ), node, function() {
-        const a = node.querySelector('a');
-        expect(a.getAttribute('href')).to.equal('/blog?the=query#hash');
-      });
+          const a = node.querySelector('a');
+          expect(a.getAttribute('href')).to.equal('/blog?the=query#hash');
+        });
     });
   });
 });

--- a/app/containers/BookView/testfile.jsx
+++ b/app/containers/BookView/testfile.jsx
@@ -7,8 +7,8 @@ describe('Containers', function() {
   describe('BookView', function() {
     beforeEach(function() {
       this.book = {
-        title: "The little engine that could",
-        description: "A book about a train that tried so hard and finally succeeded"
+        title: 'The little engine that could',
+        description: 'A book about a train that tried so hard and finally succeeded'
       };
 
       const shallowRenderer = TestUtils.createRenderer();

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ app.on('ready', function initializeElectron() {
 
     // in development, the webpack dev server serves resources from memory
     // http://goo.gl/SGwTdJ
-    mainWindow.loadURL(`http://localhost:3000`); 
+    mainWindow.loadURL(`http://localhost:8080`);
 
   } else {
     mainWindow.loadURL(`file://${__dirname}/public/index.html`);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -77,7 +77,6 @@ module.exports = function(config) {
       'karma-mocha',
       'karma-sinon',
       'karma-webpack',
-      'karma-coverage',
       'karma-mocha-reporter',
       'karma-chrome-launcher',
       'karma-sourcemap-loader'

--- a/package.json
+++ b/package.json
@@ -6,14 +6,12 @@
   "main": "index.js",
   "scripts": {
     "test": "karma start",
-    "start": "export NODE_ENV='development'; webpack-dev-server --config webpack/webpack.development.js --progress --colors --inline",
+    "start": "npm run dev-server & npm run electron",
+    "dev-server": "export NODE_ENV='development'; webpack-dev-server --config webpack/webpack.development.js --progress --colors --inline",
     "electron": "export NODE_ENV='development'; electron .",
     "clean": "rm -rf public/build"
   },
   "babel": {
-    "plugins": [
-      "transform-decorators"
-    ],
     "presets": [
       "stage-0",
       "es2015",
@@ -24,9 +22,7 @@
   "license": "ISC",
   "engine": "node >= 4.0.0",
   "dependencies": {
-    "history": "^1.13.1",
     "lodash": "^4.0.0",
-    "pouchdb": "^5.1.0",
     "react": "^0.14.2",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.6",
@@ -43,15 +39,12 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.1",
-    "babel-plugin-transform-decorators": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
-    "browser-sync": "^2.10.0",
-    "browser-sync-webpack-plugin": "^1.0.1",
     "chai": "^3.4.1",
-    "connect-history-api-fallback": "^1.1.0",
     "css-loader": "^0.23.0",
+    "electron-builder": "^3.1.1",
     "electron-debug": "^0.5.1",
     "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.36.4",
@@ -59,14 +52,11 @@
     "eslint-loader": "^1.2.0",
     "eslint-plugin-react": "^3.11.2",
     "extract-text-webpack-plugin": "^1.0.1",
-    "html-loader": "^0.4.0",
     "inject-loader": "^2.0.1",
-    "json-loader": "^0.5.4",
     "karma": "^0.13.10",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.2",
     "karma-cli": "^0.1.2",
-    "karma-coverage": "^0.5.3",
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.3",
     "karma-sinon": "^1.0.4",
@@ -79,7 +69,6 @@
     "source-map-support": "^0.4.0",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
-    "webpack-hot-middleware": "^2.6.0",
-    "webpack-target-electron-renderer": "^0.4.0"
+    "webpack-hot-middleware": "^2.6.0"
   }
 }

--- a/webpack/webpack.base.js
+++ b/webpack/webpack.base.js
@@ -53,7 +53,7 @@ module.exports = {
   module: {
     preLoaders: [
       {
-        test: /.js$x?/, loader: 'eslint', exclude: /node_modules/
+        test: /.jsx?$/, loader: 'eslint', exclude: /node_modules/
       }
     ],
 
@@ -76,12 +76,6 @@ module.exports = {
   },
   node: {
     fs: 'empty'
-  },
-  devServer: {
-    contentBase: path.join(baseDir, 'public')
-  },
-  webpackServer: {
-    noInfo: true
   },
   resolve: {
     extensions: ['', '.js', '.jsx', '.css', '.scss'],

--- a/webpack/webpack.development.js
+++ b/webpack/webpack.development.js
@@ -1,13 +1,13 @@
 /* Development Configuration
 ======================================================================= */
 var developmentConfig = require('./webpack.base.js');
-var BrowserSyncPlugin = require('browser-sync-webpack-plugin');
-var historyApiFallback = require('connect-history-api-fallback')
+var path = require('path');
+var baseDir = developmentConfig.baseDir;
 
-developmentConfig.plugins.push(
-  new BrowserSyncPlugin({
-    proxy: 'localhost:8080'
-  })
-);
+Object.assign(developmentConfig, {
+  devServer: {
+    contentBase: path.join(baseDir, 'public')
+  }
+});
 
 module.exports = developmentConfig;


### PR DESCRIPTION
# Background

Github released the ability to auto-apply templates for Pull Requests and Github Issues.  Figured this would save a lot of typing for our poor souls. Also took the chance to add a .CONTRIBUTING Github file as well, since I was already adding Github files.

# Changes

 - [x] Adds dependency information to README
 - [x] Removes unused dependencies
 - [x] Fixes typo in Webpack and move webpack-server to only run in the development build
 - [x] Fixes random style issues caused by mistyping Babel ESLint file-checking regex

# Reviewers

@aj-adams @mistermjtek @ddrabik 