### PR TITLE
Removes RxJS from BentoTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules
 /public/build
 /public/package
+/public/packages
 
 # Ignore system-created files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ Starting at React v.0.14, Facebook split out React's DOM functionality into [Rea
 - #### Redux-Thunk
 [Redux-Thunk](https://github.com/gaearon/redux-thunk) helps us deal with asynchronous tasks using action creators that return functions instead of actions.
 
-- #### Rx
-[RxJs](http://reactivex.io/) is a library that allows us to deal with asynchronous problems using the concept of observables. This is awesome because it allows us to deal with one interface when using asynchronous tasks that might normally be handled in different ways, such as api requests, streams, and listener events. Admittedly, it is not used to its fullest potential in this project because we mainly deal with simple api requests. However we thought it was a good learning opportunity and think that observables are just kinda cool. If you would like to get more into programming in this style, we'd recommend taking a look at [Jafar Husain's tutorial](http://reactivex.io/learnrx/), which is just awesome.
-
 - #### Superagent
 [Superagent](https://github.com/visionmedia/superagent) is an abstraction over javascript AJAX tools, and just makes dealing with requests really easy. We use it whenever we ping an api for Manga data.
 

--- a/app/containers/Layout/testfile.jsx
+++ b/app/containers/Layout/testfile.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { find } from "lodash";
-import { Observable } from "rx";
 import TestUtils from "react/lib/ReactTestUtils";
 
 describe("Containers", function() {
@@ -17,7 +16,7 @@ describe("Containers", function() {
 
       this.props = {
         library: { lastUpdated: "12345" },
-        dispatch: sinon.stub().returns(Observable.just({})),
+        dispatch: sinon.stub().returns(Promise.resolve()),
         params: {},
         routing: {},
         user: {}
@@ -28,6 +27,11 @@ describe("Containers", function() {
           <div className="layout__child" />
         </this.Layout>
       );
+    });
+
+    afterEach(function afterEach() {
+      this.props = null;
+      this.component = null;
     });
 
     it("Should render a div with a `layout` class", function shouldRenderLayout() {
@@ -60,7 +64,7 @@ describe("Containers", function() {
       expect(this.mockActions.fetchChapter.callCount).to.equal(0);
     });
 
-    it("Should fetch any books that need to be updated", function shouldFetchBook() {
+    it("Should fetch any books that need to be updated", function shouldFetchBook(done) {
       this.props.params.bookid = "some-book";
       this.props.library.books = {
         "some-book": {
@@ -75,12 +79,15 @@ describe("Containers", function() {
       );
 
       const book = this.props.library.books["some-book"];
-      expect(this.mockActions.fetchBook.calledWithExactly(book)).to.be.true;
       expect(this.mockActions.fetchLibrary.callCount).to.equal(0);
       expect(this.mockActions.fetchChapter.callCount).to.equal(0);
+      setTimeout(() => {
+        expect(this.mockActions.fetchBook.callCount).to.equal(1);
+        done();
+      }, 0);
     });
 
-    it("Should fetch any chapters that need to be updated", function shouldFetchChapter() {
+    it("Should fetch any chapters that need to be updated", function shouldFetchChapter(done) {
       this.props.params.bookid = "some-book";
       this.props.params.chapterid = "some-chapter";
       this.props.library.books = {
@@ -99,9 +106,12 @@ describe("Containers", function() {
 
       const book = this.props.library.books["some-book"];
       const chapter = find(book.chapters, {id: "some-chapter"});
-      expect(this.mockActions.fetchChapter.calledWithExactly(book, chapter)).to.be.true;
       expect(this.mockActions.fetchLibrary.callCount).to.equal(0);
       expect(this.mockActions.fetchBook.callCount).to.equal(0);
+      setTimeout(() => {
+        expect(this.mockActions.fetchChapter.callCount).to.equal(1);
+        done();
+      }, 0);
     });
   });
 });

--- a/app/containers/Routes/Routes.jsx
+++ b/app/containers/Routes/Routes.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Route } from "react-router";
 
 import Layout from "app/containers/Layout";
-import PageView from "app/containers/PageView";
 import BookView from "app/containers/BookView";
 import ChapterView from "app/containers/ChapterView";
 import LibraryView from "app/containers/LibraryView";
@@ -13,7 +12,6 @@ const routes = (
   <Route component={Layout}>
     <Route path="/" component={LibraryView} />
 
-    <Route path="/book/:bookid/chapter/:chapterid/page/:pageid" component={PageView} />
     <Route path="/book/:bookid/chapter/:chapterid" component={ChapterView} />
     <Route path="/book/:bookid" component={BookView} />
 

--- a/app/data/actions/bookActions/bookActions.js
+++ b/app/data/actions/bookActions/bookActions.js
@@ -29,8 +29,8 @@ export function fetchBook(book) {
   return dispatch => {
     dispatch(fetchBookRequest(book));
     return getBook$(book.id)
-      .map(function(book) {
-        return dispatch(fetchBookSuccess(book));
+      .then(function(book) {
+        return Promise.resolve(dispatch(fetchBookSuccess(book)));
       })
       .catch(function(error) {
         dispatch(fetchBookFailure(error));

--- a/app/data/actions/chapterActions/chapterActions.js
+++ b/app/data/actions/chapterActions/chapterActions.js
@@ -30,11 +30,11 @@ export function fetchChapter(book, chapter) {
   return dispatch => {
     dispatch(fetchChapterRequest(book, chapter));
     return getChapter$(chapter.id)
-      .map(function(chapter) {
-        return dispatch(fetchChapterSuccess(book, chapter));
+      .then(function(chapter) {
+        return Promise.resolve(dispatch(fetchChapterSuccess(book, chapter)));
       })
       .catch(function(error) {
-        return dispatch(fetchChapterFailure(error));
+        return Promise.reject(dispatch(fetchChapterFailure(error)));
       });
   };
 }

--- a/app/data/actions/libraryActions/libraryActions.js
+++ b/app/data/actions/libraryActions/libraryActions.js
@@ -27,11 +27,11 @@ export function fetchLibrary(libraryPage) {
   return dispatch => {
     dispatch(fetchLibraryRequest());
     return getLibrary$(libraryPage)
-      .map(function(library) {
-        return dispatch(fetchLibrarySuccess(library));
+      .then(function(library) {
+        return Promise.resolve(dispatch(fetchLibrarySuccess(library)));
       })
       .catch(function(error) {
-        return dispatch(fetchLibraryFailure(error));
+        return Promise.reject(dispatch(fetchLibraryFailure(error)));
       });
   };
 }

--- a/app/data/models/Chapter/Chapter.js
+++ b/app/data/models/Chapter/Chapter.js
@@ -12,7 +12,7 @@ Chapter.createFromMangaEdenChapterApi = function(response, chapterID) {
 };
 
 Chapter.createFromMangaEdenMangaApi = function([number, date, title, id]) {
-  return { id, number, date, title };
+  return assign(new Chapter(), { id, number, date, title });
 };
 
 Chapter.formatPage = function([pageNumber, imageUrl, width, height]) {

--- a/app/data/services/mangaEdenApi/mangaEdenApi.js
+++ b/app/data/services/mangaEdenApi/mangaEdenApi.js
@@ -1,4 +1,3 @@
-import { Observable } from "rx";
 import request from "superagent";
 
 import Library from "app/data/models/Library";
@@ -8,31 +7,40 @@ import Chapter from "app/data/models/Chapter";
 export const baseHost = "http://www.mangaeden.com/";
 export const imgHost = "http://cdn.mangaeden.com/mangasimg/";
 
-function getData(url, callback) {
-  request
-    .get(url)
-    .end((error, { body = {} }) => {
-      return callback(error, body);
-    });
+function getData(url) {
+  return new Promise(function(resolve, reject) {
+    request
+      .get(url)
+      .end(function(error, response) {
+        if(error) { return reject(error); }
+        resolve(response.body);
+      });
+  });
 }
-
-const getData$ = Observable.fromNodeCallback(getData);
 
 export function getLibrary$(pageId) {
   if(pageId !== undefined) {
-    return getData$(`${baseHost}api/list/0/?p=${pageId}`)
-      .map(response => Library.createFromMangaEdenListApi(response));
+    return getData(`${baseHost}api/list/0/?p=${pageId}`)
+      .then(response => {
+        return Promise.resolve(Library.createFromMangaEdenListApi(response));
+      });
   }
-  return getData$(`${baseHost}api/list/0/`)
-    .map(response => Library.createFromMangaEdenListApi(response));
+  return getData(`${baseHost}api/list/0/`)
+    .then(response => {
+      return Promise.resolve(Library.createFromMangaEdenListApi(response));
+    });
 }
 
 export function getBook$(bookId) {
-  return getData$(`${baseHost}api/manga/${bookId}/`)
-    .map(response => Book.createFromMangaEdenMangaApi(response, bookId));
+  return getData(`${baseHost}api/manga/${bookId}/`)
+    .then(response => {
+      return Promise.resolve(Book.createFromMangaEdenMangaApi(response, bookId));
+    });
 }
 
 export function getChapter$(chapterId) {
-  return getData$(`${baseHost}api/chapter/${chapterId}/`)
-    .map(response => Chapter.createFromMangaEdenChapterApi(response, chapterId));
+  return getData(`${baseHost}api/chapter/${chapterId}/`)
+    .then(response => {
+      return Promise.resolve(Chapter.createFromMangaEdenChapterApi(response, chapterId));
+    });
 }

--- a/app/data/services/mangaEdenApi/testfile.js
+++ b/app/data/services/mangaEdenApi/testfile.js
@@ -1,6 +1,4 @@
-import Rx from "rx";
-import { forEach } from "lodash";
-import { getData, getData$, getLibrary$, getBook$, getChapter$ } from "./mangaEdenApi";
+import { getLibrary$, getBook$, getChapter$ } from "./mangaEdenApi";
 import listApiFixture from "test/fixtures/mangaEden/listApiFixture.js";
 import mangaApiFixture from "test/fixtures/mangaEden/mangaApiFixture.js";
 import chapterApiFixture from "test/fixtures/mangaEden/chapterApiFixture.js";
@@ -19,12 +17,8 @@ describe("Data", function() {
       });
 
       it("should get the manga library", function() {
-        const observableAction = {
-          onNext: sinon.spy(),
-          onError: sinon.spy(),
-          onCompleted: sinon.spy()
-        };
-        getLibrary$().forEach(observableAction);
+        const callback = sinon.spy();
+        getLibrary$().then(callback);
 
         this.request.respond(
           200,
@@ -32,19 +26,13 @@ describe("Data", function() {
           JSON.stringify(listApiFixture)
         );
 
-        expect(observableAction.onNext.calledOnce);
-        expect(observableAction.onCompleted.calledOnce);
+        expect(callback.calledOnce);
       });
 
       it("should get manga book information", function() {
+        const callback = sinon.spy();
         const mangaID = "4e70e9f6c092255ef7004336";
-        const observableAction = {
-          onNext: sinon.spy(),
-          onError: sinon.spy(),
-          onCompleted: sinon.spy()
-        };
-
-        getBook$(mangaID).forEach(observableAction);
+        getBook$(mangaID).then(callback);
 
         this.request.respond(
           200,
@@ -52,18 +40,13 @@ describe("Data", function() {
           JSON.stringify(mangaApiFixture)
         );
 
-        expect(observableAction.onNext.calledOnce);
-        expect(observableAction.onCompleted.calledOnce);
+        expect(callback.calledOnce);
       });
 
       it("should get a chapter\'s pages", function() {
+        const callback = sinon.spy();
         const chapterID = "4e711cb0c09225616d037cc2";
-        const observableAction = {
-          onNext: sinon.spy(),
-          onError: sinon.spy(),
-          onCompleted: sinon.spy()
-        };
-        getChapter$(chapterID).forEach(observableAction);
+        getChapter$(chapterID).then(callback);
 
         this.request.respond(
           200,
@@ -71,8 +54,7 @@ describe("Data", function() {
           JSON.stringify(chapterApiFixture)
         );
 
-        expect(observableAction.onNext.calledOnce);
-        expect(observableAction.onCompleted.calledOnce);
+        expect(callback.calledOnce);
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev-build": "export NODE_ENV='development'; npm run clean && webpack --config webpack/webpack.development.js --progress --colors --inline",
     "dev-electron": "export NODE_ENV='development'; electron ./public/",
     "dev-server": "export NODE_ENV='development'; webpack-dev-server --config webpack/webpack.development.js --progress --colors --inline",
-    "clean": "rm -rf public/build"
+    "clean": "rm -rf public/build && rm -rf public/packages"
   },
   "babel": {
     "presets": [
@@ -36,7 +36,6 @@
     "redux-devtools": "^3.1.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
-    "rx": "^4.1.0",
     "superagent": "^1.8.3"
   },
   "devDependencies": {
@@ -49,11 +48,11 @@
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
     "electron-debug": "^0.6.0",
-    "electron-packager": "^6.0.0",
+    "electron-packager": "^7.0.0",
     "electron-prebuilt": "^0.37.3",
     "eslint": "^2.5.3",
     "eslint-loader": "^1.3.0",
-    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react": "^5.0.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "inject-loader": "^2.0.1",
     "karma": "^0.13.22",

--- a/public/index.js
+++ b/public/index.js
@@ -22,7 +22,11 @@ app.on("window-all-closed", function allWindowsAreClosed() {
 
 app.on("ready", function initializeElectron() {
   var server = null;
-  mainWindow = new BrowserWindow({width: 800, height: 600});
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    "web-preferences": {"web-security": false}
+  });
 
   if (process.env["NODE_ENV"] == "development") {
 

--- a/webpack/webpack.base.js
+++ b/webpack/webpack.base.js
@@ -5,17 +5,6 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 var baseDir = path.resolve(__dirname, "..");
 
-/* Inform webpack that our node modules are commonjs
-======================================================================= */
-var nodeModules = {};
-fs.readdirSync(path.join(baseDir, "node_modules"))
-  .filter(function(file) {
-    return [".bin"].indexOf(file) === -1;
-  })
-  .forEach(function(module) {
-    nodeModules[module] = "commonjs " + module;
-  });
-
 /* Set default resolution path to the same name as the folder
  * eg `app/components/Button` finds `app/components/Button/Button.js`
 ======================================================================= */


### PR DESCRIPTION
# Background

This PR removes RxJS from BentoTime. RxJS was adding another layer of complexity, taking away from the ability for people to use BentoTime as a way to learn newer ES Features, React, Redux, Webpack, and Electron. There's already a lot of complexity, and this was just raising the bar of entry. Also, this isn't a project where observables are used to their full potential anyway, since all we are doing is simple web requests that don't need to be cancelled. There's simply not a lot of reason to take on that extra bulk from Rx.

# Changes

- [x] Removes RxJS from BentoTime
- [x] Adjusts tests and documentation to match
- [x] Some tidying and dependency updating

# Reviewers

@aj-adams @ddrabik @mistermjtek 
