### PR TITLE
[refactor] Improves loading handling

### DIFF
--- a/app/renderer-process/containers/BookView/BookView.jsx
+++ b/app/renderer-process/containers/BookView/BookView.jsx
@@ -4,7 +4,9 @@ import BookHero from "renderer/components/BookHero";
 import BookInfo from "renderer/components/BookInfo";
 
 const BookView = function BookView({ book, dispatch }) {
-  if(!book) { return <h3 className="book-view--loading">loading...</h3>; }
+  if(!book || !book.chapters || book.isFetching) {
+    return <h3 className="book-view--loading">loading...</h3>;
+  }
 
   return (
     <div className="book-view">

--- a/app/renderer-process/containers/BookView/BookView__Tests.jsx
+++ b/app/renderer-process/containers/BookView/BookView__Tests.jsx
@@ -7,7 +7,8 @@ describe("Containers", function() {
     beforeEach(function() {
       this.book = {
         title: "The little engine that could",
-        description: "A book about a train that tried so hard and finally succeeded"
+        description: "A book about a train that tried so hard and finally succeeded",
+        chapters: []
       };
 
       this.component = shallow(<BookView book={this.book} />);

--- a/app/renderer-process/containers/ChapterView/ChapterView.jsx
+++ b/app/renderer-process/containers/ChapterView/ChapterView.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
-import { map } from "lodash";
+import { map, isEmpty } from "lodash";
 
 import { setChapterViewed } from "renderer/data/actions/chapterActions";
 import combineClasses from "renderer/utilities/combineClasses";
@@ -19,7 +19,7 @@ class ChapterView extends Component {
   render() {
     const { book, chapter } = this.props;
 
-    if( !book || !chapter ){
+    if( !book || !chapter || isEmpty(chapter.pages) ){
       return <h3 className="chapter-view--loading">loading...</h3>;
     }
 

--- a/app/renderer-process/containers/LibraryView/LibraryView.jsx
+++ b/app/renderer-process/containers/LibraryView/LibraryView.jsx
@@ -30,7 +30,7 @@ class LibraryView extends Component {
     const onlyShowBookmarks = !searchFilterExists;
     const dateFilter = searchFilterExists ? this.state.dateFilter : "week";
 
-    if(!library.lastUpdated) {
+    if(!library.books || library.isFetching) {
       return <h3 className="library-view--loading">loading...</h3>;
     }
 

--- a/app/renderer-process/containers/LibraryView/LibraryView__Tests.jsx
+++ b/app/renderer-process/containers/LibraryView/LibraryView__Tests.jsx
@@ -35,7 +35,7 @@ describe("Containers", function() {
       expect(bookList.prop("searchFilter")).to.equal(this.searchFilterText);
     });
 
-    it("Should render a Loading component if no book is passed in as a prop", function() {
+    it("Should render a Loading component if no library is passed in as a prop", function() {
       this.component = shallow(<LibraryView />);
       expect(this.component.text()).to.equal("loading...");
     });


### PR DESCRIPTION
Background
==========
Loading was previously not being handled well by the BookView, and styles were not consistent between views. This PR fixes these issues.

Changes
=======
- [x] Adjusts BookView to show loading screen while the property `isFetching` is true.
- [x] Adjusts styles for Library and Chapter views.

References
=========
This PR is a bit related to https://github.com/Blanket-Warriors/BentoTime/issues/17, but doesn't implement it.